### PR TITLE
Fix collaboration typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A C implementation of the Gomoku (Five-in-a-Row) game featuring an AI opponent using the MiniMax algorithm with Alpha-Beta pruning.
 
 > [!TIP]
-> This project was produced in colaboration with Claude-4-MAX, but the the original **evaluation function** was written by the author. Also, when we say "playing with AI" we do not mean LLMs, we simply mean you are playing against the computer.
+> This project was produced in collaboration with Claude-4-MAX, but the original **evaluation function** was written by the author. Also, when we say "playing with AI" we do not mean LLMs, we simply mean you are playing against the computer.
 
 ### Completed Game Screenshot
 


### PR DESCRIPTION
## Summary
- fix typos in README tip: "colaboration" -> "collaboration" and remove repeated word

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a5613116ac8321a1e22b5b0097f51e